### PR TITLE
Configurable traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Mod ([link](https://www.curseforge.com/minecraft/mc-mods/tinkers-construct)) in 
   faster THEN swap to Reinforced for 3x3? Go for it!
 * All effects/mods (when applicable) work with Vanilla Enchants. Damage, exp and durability modifications are all
   stackable and work nicely with each other.
+* Configurable traits. You can disable any trait you don't want in the configuration file.
 
 For a more detailed look, check out the video from Boomer_1 who runs through the basics of Tinker!
 [![Boomer shows off SlimeTinker](https://res.cloudinary.com/marcomontalbano/image/upload/v1626509062/video_to_markdown/images/youtube--gAUoxj-h26s-c05b58ac6eb4c4700831b2b3070cd403.jpg)](https://youtu.be/gAUoxj-h26s "Boomer shows off SlimeTinker")
@@ -31,6 +32,10 @@ For a more detailed look, check out the video from Boomer_1 who runs through the
 
 * Addition of molten metal types from even more addons!
 * Additional tiers of smeltery that will allow for further automation.
+
+## Configuration
+
+SlimeTinker now supports disabling traits. All the traits are enabled by default. To disable a trait, open the file `/plugins/SlimeTinker/traits.yml`, disable the part under a specific material.
 
 ## Suggestions?
 

--- a/src/main/java/io/github/sefiraat/slimetinker/SlimeTinker.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/SlimeTinker.java
@@ -49,10 +49,6 @@ public class SlimeTinker extends AbstractAddon {
         return instance;
     }
 
-    public TraitManager getTraitManager() {
-        return traitManager;
-    }
-
     @Override
     public void enable() {
 

--- a/src/main/java/io/github/sefiraat/slimetinker/SlimeTinker.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/SlimeTinker.java
@@ -13,6 +13,7 @@ import io.github.sefiraat.slimetinker.items.componentmaterials.CMManager;
 import io.github.sefiraat.slimetinker.items.workstations.workbench.Workbench;
 import io.github.sefiraat.slimetinker.listeners.ListenerManager;
 import io.github.sefiraat.slimetinker.managers.DispatchManager;
+import io.github.sefiraat.slimetinker.managers.TraitManager;
 import io.github.sefiraat.slimetinker.runnables.RunnableManager;
 import io.github.sefiraat.slimetinker.utils.Keys;
 import lombok.Getter;
@@ -37,6 +38,8 @@ public class SlimeTinker extends AbstractAddon {
     @Getter
     @Setter
     private Workbench workbench;
+    @Getter
+    private TraitManager traitManager;
 
     public SlimeTinker() {
         super("Sefiraat", "SlimeTinker", "master", "auto-update");
@@ -70,6 +73,7 @@ public class SlimeTinker extends AbstractAddon {
         cmManager = new CMManager();
         runnableManager = new RunnableManager();
         dispatchManager = new DispatchManager();
+        traitManager = new TraitManager();
 
         this.listenerManager = new ListenerManager(this, this.getServer().getPluginManager());
 

--- a/src/main/java/io/github/sefiraat/slimetinker/SlimeTinker.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/SlimeTinker.java
@@ -49,6 +49,10 @@ public class SlimeTinker extends AbstractAddon {
         return instance;
     }
 
+    public TraitManager getTraitManager() {
+        return traitManager;
+    }
+
     @Override
     public void enable() {
 
@@ -70,10 +74,10 @@ public class SlimeTinker extends AbstractAddon {
         Mods.set(this);
         Workstations.set(this);
 
+        traitManager = new TraitManager();
         cmManager = new CMManager();
         runnableManager = new RunnableManager();
         dispatchManager = new DispatchManager();
-        traitManager = new TraitManager();
 
         this.listenerManager = new ListenerManager(this, this.getServer().getPluginManager());
 

--- a/src/main/java/io/github/sefiraat/slimetinker/config/ConfigManager.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/config/ConfigManager.java
@@ -1,0 +1,31 @@
+package io.github.sefiraat.slimetinker.config;
+
+import java.io.File;
+
+import io.github.thebusybiscuit.slimefun4.libraries.dough.config.Config;
+
+import io.github.sefiraat.slimetinker.SlimeTinker;
+
+/**
+ * Basic config file manager
+ */
+public class ConfigManager {
+    private final String filename;
+    private final Config config;
+
+    public ConfigManager(String filename) {
+        this.filename = filename;
+
+        File file = new File(SlimeTinker.inst().getDataFolder(), filename);
+        if (!file.exists()) {
+            file.getParentFile().mkdirs();
+            SlimeTinker.inst().saveResource(filename, true);
+        }
+
+        this.config = new Config(SlimeTinker.inst(), filename);
+    }
+
+    public Config getConfig() {
+        return this.config;
+    }
+}

--- a/src/main/java/io/github/sefiraat/slimetinker/events/friend/EventChannels.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/events/friend/EventChannels.java
@@ -3,7 +3,9 @@ package io.github.sefiraat.slimetinker.events.friend;
 import io.github.sefiraat.slimetinker.SlimeTinker;
 import io.github.sefiraat.slimetinker.items.componentmaterials.CMManager;
 import io.github.sefiraat.slimetinker.items.componentmaterials.ComponentMaterial;
+import io.github.sefiraat.slimetinker.managers.TraitManager;
 import io.github.sefiraat.slimetinker.utils.Experience;
+import io.github.sefiraat.slimetinker.utils.IDStrings;
 import io.github.sefiraat.slimetinker.utils.ItemUtils;
 import io.github.sefiraat.slimetinker.utils.ThemeUtils;
 import lombok.experimental.UtilityClass;
@@ -79,9 +81,17 @@ public class EventChannels {
         ComponentMaterial binderMaterial = CMManager.getMAP().get(matPropertyBinding);
         ComponentMaterial rodMaterial = CMManager.getMAP().get(matPropertyRod);
 
-        if (headMaterial != null) headMaterial.runEvent(friend.getEventType(), TraitPartType.HEAD, friend);
-        if (binderMaterial != null) binderMaterial.runEvent(friend.getEventType(), TraitPartType.BINDER, friend);
-        if (rodMaterial != null) rodMaterial.runEvent(friend.getEventType(), TraitPartType.ROD, friend);
+        TraitManager manager = SlimeTinker.inst().getTraitManager();
+
+        if (headMaterial != null && manager.isEnabled(matPropertyHead, IDStrings.HEAD)) {
+            headMaterial.runEvent(friend.getEventType(), TraitPartType.HEAD, friend);
+        }
+        if (binderMaterial != null && manager.isEnabled(matPropertyBinding, IDStrings.BINDING)) {
+            binderMaterial.runEvent(friend.getEventType(), TraitPartType.BINDER, friend);
+        }
+        if (rodMaterial != null && manager.isEnabled(matPropertyRod, IDStrings.ROD)) {
+            rodMaterial.runEvent(friend.getEventType(), TraitPartType.ROD, friend);
+        }
 
     }
 
@@ -172,9 +182,17 @@ public class EventChannels {
         ComponentMaterial gambesonMaterial = CMManager.getMAP().get(matPropertyGambeson);
         ComponentMaterial linksMaterial = CMManager.getMAP().get(matPropertyLinks);
 
-        if (plateMaterial != null) plateMaterial.runEvent(friend.getEventType(), TraitPartType.PLATE, friend);
-        if (gambesonMaterial != null) gambesonMaterial.runEvent(friend.getEventType(), TraitPartType.GAMBESON, friend);
-        if (linksMaterial != null) linksMaterial.runEvent(friend.getEventType(), TraitPartType.LINKS, friend);
+        TraitManager manager = SlimeTinker.inst().getTraitManager();
+
+        if (plateMaterial != null && manager.isEnabled(matPropertyPlate, IDStrings.PLATE)) {
+            plateMaterial.runEvent(friend.getEventType(), TraitPartType.PLATE, friend);
+        }
+        if (gambesonMaterial != null && manager.isEnabled(matPropertyGambeson, IDStrings.GAMBESON)) {
+            gambesonMaterial.runEvent(friend.getEventType(), TraitPartType.GAMBESON, friend);
+        }
+        if (linksMaterial != null && manager.isEnabled(matPropertyLinks, IDStrings.LINKS)) {
+            linksMaterial.runEvent(friend.getEventType(), TraitPartType.LINKS, friend);
+        }
 
     }
 

--- a/src/main/java/io/github/sefiraat/slimetinker/items/componentmaterials/CMManager.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/items/componentmaterials/CMManager.java
@@ -1,5 +1,6 @@
 package io.github.sefiraat.slimetinker.items.componentmaterials;
 
+import io.github.sefiraat.slimetinker.SlimeTinker;
 import io.github.sefiraat.slimetinker.events.friend.TraitPartType;
 import io.github.sefiraat.slimetinker.items.Casts;
 import io.github.sefiraat.slimetinker.items.Dies;
@@ -14,6 +15,8 @@ import io.github.sefiraat.slimetinker.items.componentmaterials.cmfactories.CMSli
 import io.github.sefiraat.slimetinker.items.componentmaterials.cmrecipes.CastResult;
 import io.github.sefiraat.slimetinker.items.componentmaterials.cmrecipes.MoltenResult;
 import io.github.sefiraat.slimetinker.managers.SupportedPluginsManager;
+import io.github.sefiraat.slimetinker.managers.TraitManager;
+import io.github.sefiraat.slimetinker.utils.IDStrings;
 import io.github.sefiraat.slimetinker.utils.ItemUtils;
 import lombok.Getter;
 import net.md_5.bungee.api.ChatColor;
@@ -26,23 +29,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static io.github.sefiraat.slimetinker.utils.IDStrings.AXE;
-import static io.github.sefiraat.slimetinker.utils.IDStrings.BOOTS;
-import static io.github.sefiraat.slimetinker.utils.IDStrings.BRASS;
-import static io.github.sefiraat.slimetinker.utils.IDStrings.CHESTPLATE;
-import static io.github.sefiraat.slimetinker.utils.IDStrings.GOLD;
-import static io.github.sefiraat.slimetinker.utils.IDStrings.HEAD;
-import static io.github.sefiraat.slimetinker.utils.IDStrings.HELMET;
-import static io.github.sefiraat.slimetinker.utils.IDStrings.HOE;
-import static io.github.sefiraat.slimetinker.utils.IDStrings.LEGGINGS;
-import static io.github.sefiraat.slimetinker.utils.IDStrings.LINKS;
-import static io.github.sefiraat.slimetinker.utils.IDStrings.PICKAXE;
-import static io.github.sefiraat.slimetinker.utils.IDStrings.PLATE;
-import static io.github.sefiraat.slimetinker.utils.IDStrings.REPAIR;
-import static io.github.sefiraat.slimetinker.utils.IDStrings.ROD;
-import static io.github.sefiraat.slimetinker.utils.IDStrings.SHOVEL;
-import static io.github.sefiraat.slimetinker.utils.IDStrings.SWORD;
 
 public class CMManager {
 
@@ -147,6 +133,8 @@ public class CMManager {
             MAP.putAll(CMLiteXpansion.getMap());
         }
 
+        TraitManager traitManager = SlimeTinker.inst().getTraitManager();
+
         // Add melting recipes
         for (Map.Entry<String, ComponentMaterial> entry : MAP.entrySet()) {
 
@@ -154,21 +142,31 @@ public class CMManager {
             String id = entry.getKey();
 
             // Tools, armour and kits (referenced through dummy)
-            if (cm.isValidToolRod()) MAP_CAST_TOOLROD.put(cm, Parts.TOOL_ROD.getStack(id, ROD, null, cm.getColor()));
-            if (cm.isValidLinks()) MAP_CAST_ARMOUR_MAIL.put(cm, Parts.MAIL_LINKS.getStack(id, LINKS, null, cm.getColor()));
+            if (cm.isValidToolRod() & traitManager.isEnabled(id, IDStrings.ROD)) {
+                MAP_CAST_TOOLROD.put(cm, Parts.TOOL_ROD.getStack(id, IDStrings.ROD, null, cm.getColor()));
+            }
+            if (cm.isValidLinks() & traitManager.isEnabled(id, IDStrings.LINKS)) {
+                MAP_CAST_ARMOUR_MAIL.put(cm, Parts.MAIL_LINKS.getStack(id, IDStrings.LINKS, null, cm.getColor()));
+            }
 
-            if (cm.isValidToolHead()) MAP_CAST_SWORDBLADE.put(cm, Parts.SWORD_BLADE.getStack(id, HEAD, SWORD, cm.getColor()));
-            if (cm.isValidToolHead()) MAP_CAST_HOEHEAD.put(cm, Parts.HOE_HEAD.getStack(id, HEAD, HOE, cm.getColor()));
-            if (cm.isValidToolHead()) MAP_CAST_AXEHEAD.put(cm, Parts.AXE_HEAD.getStack(id, HEAD, AXE, cm.getColor()));
-            if (cm.isValidToolHead()) MAP_CAST_PICKAXEHEAD.put(cm, Parts.PICKAXE_HEAD.getStack(id, HEAD, PICKAXE, cm.getColor()));
-            if (cm.isValidToolHead()) MAP_CAST_SHOVELHEAD.put(cm, Parts.SHOVEL_HEAD.getStack(id, HEAD, SHOVEL, cm.getColor()));
+            if (cm.isValidToolHead() & traitManager.isEnabled(id, IDStrings.HEAD)) {
+                MAP_CAST_SWORDBLADE.put(cm, Parts.SWORD_BLADE.getStack(id, IDStrings.HEAD, IDStrings.SWORD, cm.getColor()));
+                MAP_CAST_HOEHEAD.put(cm, Parts.HOE_HEAD.getStack(id, IDStrings.HEAD, IDStrings.HOE, cm.getColor()));
+                MAP_CAST_AXEHEAD.put(cm, Parts.AXE_HEAD.getStack(id, IDStrings.HEAD, IDStrings.AXE, cm.getColor()));
+                MAP_CAST_PICKAXEHEAD.put(cm, Parts.PICKAXE_HEAD.getStack(id, IDStrings.HEAD, IDStrings.PICKAXE, cm.getColor()));
+                MAP_CAST_SHOVELHEAD.put(cm, Parts.SHOVEL_HEAD.getStack(id, IDStrings.HEAD, IDStrings.SHOVEL, cm.getColor()));
+            }
 
-            if (cm.isValidPlates()) MAP_CAST_ARMOUR_PLATES_HELM.put(cm, Parts.HELM_PLATE.getStack(id, PLATE, HELMET, cm.getColor()));
-            if (cm.isValidPlates()) MAP_CAST_ARMOUR_PLATES_CHEST.put(cm, Parts.CHEST_PLATE.getStack(id, PLATE, CHESTPLATE, cm.getColor()));
-            if (cm.isValidPlates()) MAP_CAST_ARMOUR_PLATES_LEGGINGS.put(cm, Parts.LEG_PLATE.getStack(id, PLATE, LEGGINGS, cm.getColor()));
-            if (cm.isValidPlates()) MAP_CAST_ARMOUR_PLATES_BOOTS.put(cm, Parts.BOOT_PLATE.getStack(id, PLATE, BOOTS, cm.getColor()));
+            if (cm.isValidPlates() & traitManager.isEnabled(id, IDStrings.PLATE)) {
+                MAP_CAST_ARMOUR_PLATES_HELM.put(cm, Parts.HELM_PLATE.getStack(id, IDStrings.PLATE, IDStrings.HELMET, cm.getColor()));
+                MAP_CAST_ARMOUR_PLATES_CHEST.put(cm, Parts.CHEST_PLATE.getStack(id, IDStrings.PLATE, IDStrings.CHESTPLATE, cm.getColor()));
+                MAP_CAST_ARMOUR_PLATES_LEGGINGS.put(cm, Parts.LEG_PLATE.getStack(id, IDStrings.PLATE, IDStrings.LEGGINGS, cm.getColor()));
+                MAP_CAST_ARMOUR_PLATES_BOOTS.put(cm, Parts.BOOT_PLATE.getStack(id, IDStrings.PLATE, IDStrings.BOOTS, cm.getColor()));
+            }
 
-            if (cm.isValidToolHead()) MAP_CAST_REPAIRKIT.put(cm, Parts.REPAIR_KIT.getStack(id, REPAIR, cm.getColor())); // We use HEAD here are repair always goes by head material
+            if (cm.isValidToolHead() || cm.isValidPlates()) {
+                MAP_CAST_REPAIRKIT.put(cm, Parts.REPAIR_KIT.getStack(id, IDStrings.REPAIR, cm.getColor())); // We use HEAD here are repair always goes by head material
+            }
 
             // Gems
             if (cm.getFormGem() != null) {
@@ -292,22 +290,22 @@ public class CMManager {
     }
 
     private void fillDieMetals() {
-        MAP_DIE_NUGGET.put(CMManager.getById(GOLD), Casts.CAST_NUGGET);
-        MAP_DIE_INGOT.put(CMManager.getById(GOLD), Casts.CAST_INGOT);
-        MAP_DIE_BLOCK.put(CMManager.getById(GOLD), Casts.CAST_BLOCK);
-        MAP_DIE_GEM.put(CMManager.getById(GOLD), Casts.CAST_GEM);
-        MAP_DIE_REPAIRKIT.put(CMManager.getById(GOLD), Casts.CAST_REPAIRKIT);
-        MAP_DIE_SHOVELHEAD.put(CMManager.getById(BRASS), Casts.CAST_SHOVELHEAD);
-        MAP_DIE_PICKAXEHEAD.put(CMManager.getById(BRASS), Casts.CAST_PICKAXEHEAD);
-        MAP_DIE_AXEHEAD.put(CMManager.getById(BRASS), Casts.CAST_AXEHEAD);
-        MAP_DIE_HOEHEAD.put(CMManager.getById(BRASS), Casts.CAST_HOEHEAD);
-        MAP_DIE_SWORDBLADE.put(CMManager.getById(BRASS), Casts.CAST_SWORDBLADE);
-        MAP_DIE_TOOLROD.put(CMManager.getById(BRASS), Casts.CAST_TOOLROD);
-        MAP_DIE_ARMOUR_PLATES_HELM.put(CMManager.getById(BRASS), Casts.CAST_HELM_PLATE);
-        MAP_DIE_ARMOUR_PLATES_CHEST.put(CMManager.getById(BRASS), Casts.CAST_CHEST_PLATE);
-        MAP_DIE_ARMOUR_PLATES_LEGGINGS.put(CMManager.getById(BRASS), Casts.CAST_LEG_PLATE);
-        MAP_DIE_ARMOUR_PLATES_BOOTS.put(CMManager.getById(BRASS), Casts.CAST_BOOT_PLATE);
-        MAP_DIE_ARMOUR_MAIL.put(CMManager.getById(BRASS), Casts.CAST_MAIL_LINK);
+        MAP_DIE_NUGGET.put(CMManager.getById(IDStrings.GOLD), Casts.CAST_NUGGET);
+        MAP_DIE_INGOT.put(CMManager.getById(IDStrings.GOLD), Casts.CAST_INGOT);
+        MAP_DIE_BLOCK.put(CMManager.getById(IDStrings.GOLD), Casts.CAST_BLOCK);
+        MAP_DIE_GEM.put(CMManager.getById(IDStrings.GOLD), Casts.CAST_GEM);
+        MAP_DIE_REPAIRKIT.put(CMManager.getById(IDStrings.GOLD), Casts.CAST_REPAIRKIT);
+        MAP_DIE_SHOVELHEAD.put(CMManager.getById(IDStrings.BRASS), Casts.CAST_SHOVELHEAD);
+        MAP_DIE_PICKAXEHEAD.put(CMManager.getById(IDStrings.BRASS), Casts.CAST_PICKAXEHEAD);
+        MAP_DIE_AXEHEAD.put(CMManager.getById(IDStrings.BRASS), Casts.CAST_AXEHEAD);
+        MAP_DIE_HOEHEAD.put(CMManager.getById(IDStrings.BRASS), Casts.CAST_HOEHEAD);
+        MAP_DIE_SWORDBLADE.put(CMManager.getById(IDStrings.BRASS), Casts.CAST_SWORDBLADE);
+        MAP_DIE_TOOLROD.put(CMManager.getById(IDStrings.BRASS), Casts.CAST_TOOLROD);
+        MAP_DIE_ARMOUR_PLATES_HELM.put(CMManager.getById(IDStrings.BRASS), Casts.CAST_HELM_PLATE);
+        MAP_DIE_ARMOUR_PLATES_CHEST.put(CMManager.getById(IDStrings.BRASS), Casts.CAST_CHEST_PLATE);
+        MAP_DIE_ARMOUR_PLATES_LEGGINGS.put(CMManager.getById(IDStrings.BRASS), Casts.CAST_LEG_PLATE);
+        MAP_DIE_ARMOUR_PLATES_BOOTS.put(CMManager.getById(IDStrings.BRASS), Casts.CAST_BOOT_PLATE);
+        MAP_DIE_ARMOUR_MAIL.put(CMManager.getById(IDStrings.BRASS), Casts.CAST_MAIL_LINK);
     }
 
     private void fillCastingDies() {

--- a/src/main/java/io/github/sefiraat/slimetinker/items/componentmaterials/ComponentMaterial.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/items/componentmaterials/ComponentMaterial.java
@@ -15,6 +15,7 @@ import io.github.sefiraat.slimetinker.items.componentmaterials.cmelements.CMTrai
 import io.github.sefiraat.slimetinker.items.templates.PartTemplate;
 import io.github.sefiraat.slimetinker.items.workstations.smeltery.DummySmeltery;
 import io.github.sefiraat.slimetinker.items.workstations.workbench.Workbench;
+import io.github.sefiraat.slimetinker.managers.TraitManager;
 import io.github.sefiraat.slimetinker.utils.IDStrings;
 import io.github.sefiraat.slimetinker.utils.SkullTextures;
 import io.github.sefiraat.slimetinker.utils.ThemeUtils;
@@ -96,68 +97,63 @@ public class ComponentMaterial {
 
     public void registerParts() {
 
+        TraitManager traitManager = SlimeTinker.inst().getTraitManager();
+
         // Heads (and repair kits)
-        if (cmToolMakeup.isValidHead()) {
+        if (cmToolMakeup.isValidHead() && traitManager.isEnabled(cmIdentity.getId(), IDStrings.HEAD)) {
             //CMManager.getMAP_CAST_SWORDBLADE().put(this, Parts.SWORD_BLADE.getStack(cmIdentity.getId(), HEAD, SWORD, getColor()));
             new PartTemplate(ItemGroups.PART_DICT, headStack(cmIdentity.getId(), "SWORD", SkullTextures.PART_SWORD_BLADE), DummySmeltery.TYPE, basicRecipe(Casts.CAST_SWORDBLADE, getLiquidItemStack(2)), cmIdentity.getId()).register(SlimeTinker.inst());
-        }
-        if (cmToolMakeup.isValidHead()) {
+
             //CMManager.getMAP_CAST_HOEHEAD().put(this, Parts.HOE_HEAD.getStack(cmIdentity.getId(), HEAD, HOE, getColor()));
             new PartTemplate(ItemGroups.PART_DICT, headStack(cmIdentity.getId(), "HOE", SkullTextures.PART_HOE_HEAD), DummySmeltery.TYPE, basicRecipe(Casts.CAST_HOEHEAD, getLiquidItemStack(1)), cmIdentity.getId()).register(SlimeTinker.inst());
-        }
-        if (cmToolMakeup.isValidHead()) {
+
             //CMManager.getMAP_CAST_AXEHEAD().put(this, Parts.AXE_HEAD.getStack(cmIdentity.getId(), HEAD, AXE, getColor()));
             new PartTemplate(ItemGroups.PART_DICT, headStack(cmIdentity.getId(), "AXE", SkullTextures.PART_AXE_HEAD), DummySmeltery.TYPE, basicRecipe(Casts.CAST_AXEHEAD, getLiquidItemStack(1)), cmIdentity.getId()).register(SlimeTinker.inst());
-        }
-        if (cmToolMakeup.isValidHead()) {
+
             //CMManager.getMAP_CAST_PICKAXEHEAD().put(this, Parts.PICKAXE_HEAD.getStack(cmIdentity.getId(), HEAD, PICKAXE, getColor()));
             new PartTemplate(ItemGroups.PART_DICT, headStack(cmIdentity.getId(), "PICK", SkullTextures.PART_PICKAXE_HEAD), DummySmeltery.TYPE, basicRecipe(Casts.CAST_PICKAXEHEAD, getLiquidItemStack(1)), cmIdentity.getId()).register(SlimeTinker.inst());
-        }
-        if (cmToolMakeup.isValidHead()) {
+
             //CMManager.getMAP_CAST_SHOVELHEAD().put(this, Parts.SHOVEL_HEAD.getStack(cmIdentity.getId(), HEAD, SHOVEL, getColor()));
             new PartTemplate(ItemGroups.PART_DICT, headStack(cmIdentity.getId(), "SHOVEL", SkullTextures.PART_SHOVEL_HEAD), DummySmeltery.TYPE, basicRecipe(Casts.CAST_SHOVELHEAD, getLiquidItemStack(1)), cmIdentity.getId()).register(SlimeTinker.inst());
         }
 
         // Binders
-        if (this.cmToolMakeup.isValidBinder()) {
+        if (this.cmToolMakeup.isValidBinder() & traitManager.isEnabled(cmIdentity.getId(), IDStrings.BINDING)) {
             PartTemplate binder = new PartTemplate(ItemGroups.DUMMY, bindingStack(cmIdentity.getId()), Workbench.TYPE, bindingRecipe(cmIdentity.getRepresentativeStack()), cmIdentity.getId());
             binder.setHidden(true);
             binder.register(SlimeTinker.inst());
         }
 
         // Tool Rods
-        if (cmToolMakeup.isValidRod()) {
+        if (cmToolMakeup.isValidRod() & traitManager.isEnabled(cmIdentity.getId(), IDStrings.ROD)) {
             //CMManager.getMAP_CAST_TOOLROD().put(this, Parts.TOOL_ROD.getStack(cmIdentity.getId(), ROD, null, getColor()));
             new PartTemplate(ItemGroups.PART_DICT, rodStack(cmIdentity.getId()), DummySmeltery.TYPE, basicRecipe(Casts.CAST_TOOLROD, getLiquidItemStack(1)), cmIdentity.getId()).register(SlimeTinker.inst());
         }
 
         // Plates
-        if (cmToolMakeup.isValidPlates()) {
+        if (cmToolMakeup.isValidPlates() & traitManager.isEnabled(cmIdentity.getId(), IDStrings.PLATE)) {
             //CMManager.MAP_CAST_ARMOUR_PLATES_HELM.put(this, Parts.HELM_PLATE.getStack(cmIdentity.getId(), PLATE, HELMET, getColor()));
             new PartTemplate(ItemGroups.PART_DICT, platesStack(cmIdentity.getId(), "HELMET", SkullTextures.PART_HELM_PLATES), DummySmeltery.TYPE, basicRecipe(Casts.CAST_HELM_PLATE, getLiquidItemStack(CMManager.AMOUNT_ARM_HELM)), cmIdentity.getId()).register(SlimeTinker.inst());
-        }
-        if (cmToolMakeup.isValidPlates()) {
+
             //CMManager.MAP_CAST_ARMOUR_PLATES_CHEST.put(this, Parts.CHEST_PLATE.getStack(cmIdentity.getId(), PLATE, CHESTPLATE, getColor()));
             new PartTemplate(ItemGroups.PART_DICT, platesStack(cmIdentity.getId(), "CHESTPLATE", SkullTextures.PART_CHEST_PLATES), DummySmeltery.TYPE, basicRecipe(Casts.CAST_CHEST_PLATE, getLiquidItemStack(CMManager.AMOUNT_ARM_CHEST)), cmIdentity.getId()).register(SlimeTinker.inst());
-        }
-        if (cmToolMakeup.isValidPlates()) {
+
             //CMManager.MAP_CAST_ARMOUR_PLATES_LEGGINGS.put(this, Parts.LEG_PLATE.getStack(cmIdentity.getId(), PLATE, LEGGINGS, getColor()));
             new PartTemplate(ItemGroups.PART_DICT, platesStack(cmIdentity.getId(), "LEGGINGS", SkullTextures.PART_LEG_PLATES), DummySmeltery.TYPE, basicRecipe(Casts.CAST_LEG_PLATE, getLiquidItemStack(CMManager.AMOUNT_ARM_LEG)), cmIdentity.getId()).register(SlimeTinker.inst());
-        }
-        if (cmToolMakeup.isValidPlates()) {
+
             //CMManager.MAP_CAST_ARMOUR_PLATES_BOOTS.put(this, Parts.BOOT_PLATE.getStack(cmIdentity.getId(), PLATE, BOOTS, getColor()));
             new PartTemplate(ItemGroups.PART_DICT, platesStack(cmIdentity.getId(), "BOOTS", SkullTextures.PART_BOOTS_PLATES), DummySmeltery.TYPE, basicRecipe(Casts.CAST_BOOT_PLATE, getLiquidItemStack(CMManager.AMOUNT_ARM_BOOT)), cmIdentity.getId()).register(SlimeTinker.inst());
         }
 
         // Gambeson
-        if (this.cmToolMakeup.isValidGambeson()) {
+        if (this.cmToolMakeup.isValidGambeson() && traitManager.isEnabled(cmIdentity.getId(), IDStrings.GAMBESON)) {
             PartTemplate gambeson = new PartTemplate(ItemGroups.DUMMY, gambesonStack(cmIdentity.getId()), Workbench.TYPE, gambesonRecipe(cmIdentity.getRepresentativeStack()), cmIdentity.getId());
             gambeson.setHidden(true);
             gambeson.register(SlimeTinker.inst());
         }
 
         // Mail Links
-        if (cmToolMakeup.isValidLinks()) {
+        if (cmToolMakeup.isValidLinks() & traitManager.isEnabled(cmIdentity.getId(), IDStrings.LINKS)) {
             //CMManager.getMAP_CAST_ARMOUR_MAIL().put(this, Parts.MAIL_LINKS.getStack(cmIdentity.getId(), LINKS, null, getColor()));
             new PartTemplate(ItemGroups.PART_DICT, linksStack(cmIdentity.getId()), DummySmeltery.TYPE, basicRecipe(Casts.CAST_MAIL_LINK, getLiquidItemStack(CMManager.AMOUNT_ARM_LINKS)), cmIdentity.getId()).register(SlimeTinker.inst());
         }

--- a/src/main/java/io/github/sefiraat/slimetinker/items/componentmaterials/cmelements/CMTraits.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/items/componentmaterials/cmelements/CMTraits.java
@@ -1,7 +1,10 @@
 package io.github.sefiraat.slimetinker.items.componentmaterials.cmelements;
 
+import io.github.sefiraat.slimetinker.SlimeTinker;
 import io.github.sefiraat.slimetinker.items.componentmaterials.ComponentMaterial;
 import io.github.sefiraat.slimetinker.managers.SupportedPluginsManager;
+import io.github.sefiraat.slimetinker.managers.TraitManager;
+import io.github.sefiraat.slimetinker.utils.IDStrings;
 import io.github.sefiraat.slimetinker.utils.SkullTextures;
 import io.github.sefiraat.slimetinker.utils.ThemeUtils;
 import io.github.sefiraat.slimetinker.utils.enums.ThemeItemType;
@@ -113,27 +116,29 @@ public class CMTraits {
 
     public void setupTraits(ComponentMaterial parent) {
         this.parent = parent;
+        TraitManager manager = SlimeTinker.inst().getTraitManager();
 
-        if (traitHead != null) {
+        if (traitHead != null && manager.getTraitStatus(this.materialID, IDStrings.HEAD)) {
             traitHead.setupTrait(this, parent);
         }
-        if (traitBind != null) {
+        if (traitBind != null && manager.getTraitStatus(this.materialID, IDStrings.BINDING)) {
             traitBind.setupTrait(this, parent);
         }
-        if (traitRod != null) {
+        if (traitRod != null && manager.getTraitStatus(this.materialID, IDStrings.ROD)) {
             traitRod.setupTrait(this, parent);
         }
 
-        if (traitPlates != null) {
+        if (traitPlates != null && manager.getTraitStatus(this.materialID, IDStrings.PLATE)) {
             traitPlates.setupTrait(this, parent);
         }
-        if (traitGambeson != null) {
+        if (traitGambeson != null && manager.getTraitStatus(this.materialID, IDStrings.GAMBESON)) {
             traitGambeson.setupTrait(this, parent);
         }
-        if (traitLinks != null) {
+        if (traitLinks != null && manager.getTraitStatus(this.materialID, IDStrings.LINKS)) {
             traitLinks.setupTrait(this, parent);
         }
 
+        manager.save();
     }
 
 }

--- a/src/main/java/io/github/sefiraat/slimetinker/items/componentmaterials/cmelements/CMTraits.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/items/componentmaterials/cmelements/CMTraits.java
@@ -118,23 +118,23 @@ public class CMTraits {
         this.parent = parent;
         TraitManager manager = SlimeTinker.inst().getTraitManager();
 
-        if (traitHead != null && manager.getTraitStatus(this.materialID, IDStrings.HEAD)) {
+        if (traitHead != null && manager.getEnabled(this.materialID, IDStrings.HEAD)) {
             traitHead.setupTrait(this, parent);
         }
-        if (traitBind != null && manager.getTraitStatus(this.materialID, IDStrings.BINDING)) {
+        if (traitBind != null && manager.getEnabled(this.materialID, IDStrings.BINDING)) {
             traitBind.setupTrait(this, parent);
         }
-        if (traitRod != null && manager.getTraitStatus(this.materialID, IDStrings.ROD)) {
+        if (traitRod != null && manager.getEnabled(this.materialID, IDStrings.ROD)) {
             traitRod.setupTrait(this, parent);
         }
 
-        if (traitPlates != null && manager.getTraitStatus(this.materialID, IDStrings.PLATE)) {
+        if (traitPlates != null && manager.getEnabled(this.materialID, IDStrings.PLATE)) {
             traitPlates.setupTrait(this, parent);
         }
-        if (traitGambeson != null && manager.getTraitStatus(this.materialID, IDStrings.GAMBESON)) {
+        if (traitGambeson != null && manager.getEnabled(this.materialID, IDStrings.GAMBESON)) {
             traitGambeson.setupTrait(this, parent);
         }
-        if (traitLinks != null && manager.getTraitStatus(this.materialID, IDStrings.LINKS)) {
+        if (traitLinks != null && manager.getEnabled(this.materialID, IDStrings.LINKS)) {
             traitLinks.setupTrait(this, parent);
         }
 

--- a/src/main/java/io/github/sefiraat/slimetinker/items/templates/PartTemplate.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/items/templates/PartTemplate.java
@@ -7,6 +7,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.UnplaceableBlock;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
+
 import lombok.Getter;
 import net.md_5.bungee.api.ChatColor;
 import org.apache.commons.lang.Validate;

--- a/src/main/java/io/github/sefiraat/slimetinker/managers/TraitManager.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/managers/TraitManager.java
@@ -14,14 +14,27 @@ public class TraitManager {
     }
 
     /**
-     * Get the trait status in the config file
+     * If the trait is enabled in the config.
+     * If the config does not exist, set to true by default.
      *
      * @param material the material of trait
      * @param part the part of trait
      * @return if the trait is enabled in the config
      */
-    public boolean getTraitStatus(String material, String part) {
+    public boolean getEnabled(String material, String part) {
         return this.config.getConfig().getOrSetDefault(material + "." + part, true);
+    }
+
+    /**
+     * If the trait is enabled in the config.
+     * This will not set the default value.
+     *
+     * @param material the material of trait
+     * @param part the part of trait
+     * @return if the trait is enabled in the config
+     */
+    public boolean isEnabled(String material, String part) {
+        return this.config.getConfig().getBoolean(material + "." + part);
     }
 
     /**

--- a/src/main/java/io/github/sefiraat/slimetinker/managers/TraitManager.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/managers/TraitManager.java
@@ -23,4 +23,11 @@ public class TraitManager {
     public boolean getTraitStatus(String material, String part) {
         return this.config.getConfig().getOrSetDefault(material + "." + part, true);
     }
+
+    /**
+     * Save the file
+     */
+    public void save() {
+        this.config.getConfig().save();
+    }
 }

--- a/src/main/java/io/github/sefiraat/slimetinker/managers/TraitManager.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/managers/TraitManager.java
@@ -1,0 +1,26 @@
+package io.github.sefiraat.slimetinker.managers;
+
+import io.github.sefiraat.slimetinker.config.ConfigManager;
+
+/**
+ * This class manages the traits.
+ */
+public class TraitManager {
+
+    private ConfigManager config;
+
+    public TraitManager() {
+        this.config = new ConfigManager("traits.yml");
+    }
+
+    /**
+     * Get the trait status in the config file
+     *
+     * @param material the material of trait
+     * @param part the part of trait
+     * @return if the trait is enabled in the config
+     */
+    public boolean getTraitStatus(String material, String part) {
+        return this.config.getConfig().getOrSetDefault(material + "." + part, true);
+    }
+}


### PR DESCRIPTION
Allow server owners to configure which trait they would like to enable/disable.

This will create `/plugins/SlimeTinker/traits.yml` file. In this file you can see available materials and parts.  
By setting a part to `false`, you disable this trait. This will:

* make the trait disappear from traits guide
* make the part disappear from parts guide
* disable the crafting/casting of this part
* deactivate existing trait (you can still keep this part but it will not work until its re-enabled)

SlimeTinker will not generate config for materials in not-installed addons.