### PR TITLE
Fixed trait bugs

### DIFF
--- a/src/main/java/io/github/sefiraat/slimetinker/events/BlockBreakEvents.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/events/BlockBreakEvents.java
@@ -73,6 +73,10 @@ public final class BlockBreakEvents {
         friend.setToolExpMod(friend.getToolExpMod() + 1);
     }
 
+    public static void rodSteel(EventFriend friend) {
+        friend.incrementItemExpMod(0.5);
+    }
+
     public static void rodAluBrass(EventFriend friend) {
         friend.setToolExpMod(friend.getToolExpMod() + 0.5);
         friend.setPlayerExpMod(friend.getPlayerExpMod() + 0.5);

--- a/src/main/java/io/github/sefiraat/slimetinker/events/EntityDamageEvents.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/events/EntityDamageEvents.java
@@ -124,6 +124,10 @@ public final class EntityDamageEvents {
         e.getWorld().spawnParticle(Particle.REDSTONE, e.getLocation(), 50, 1.5, 1.5, 1.5, 1, dustOptions);
     }
 
+    public static void rodSteel(EventFriend friend) {
+        friend.incrementItemExpMod(0.5);
+    }
+
     public static void headBrass(EventFriend friend) {
         friend.setDamageMod(friend.getDamageMod() + 0.5);
     }

--- a/src/main/java/io/github/sefiraat/slimetinker/events/TickEvents.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/events/TickEvents.java
@@ -789,7 +789,6 @@ public final class TickEvents {
     }
 
     public static void rodSteel(EventFriend friend) {
-        friend.incrementItemExpMod(0.5);
         increaseEffect(PotionEffectType.SPEED, friend.getPotionEffects());
     }
 

--- a/src/main/java/io/github/sefiraat/slimetinker/items/tinkermaterials/setup/Traits.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/items/tinkermaterials/setup/Traits.java
@@ -51,7 +51,7 @@ public final class Traits {
         .setAddedBy(SupportedPluginsManager.CORE_NOTE)
         .setTraitName("Rusty")
         .setLore(
-            "Armour durability loss +10%. Player Exp gain +10%"
+            "Outgoing damage reduced by 10%. Player Exp gain +10%"
         )
         .addConsumer(TraitEventType.ENTITY_DAMAGED, EntityDamageEvents::linksIron);
 
@@ -375,7 +375,9 @@ public final class Traits {
         .setLore(
             "Tool Exp +50%. Speed + 1"
         )
-        .addConsumer(TraitEventType.TICK, TickEvents::rodSteel);
+        .addConsumer(TraitEventType.TICK, TickEvents::rodSteel)
+        .addConsumer(TraitEventType.ENTITY_DAMAGED, EntityDamageEvents::rodSteel)
+        .addConsumer(TraitEventType.BLOCK_BREAK, BlockBreakEvents::rodSteel);
 
     public static final MaterialTrait CORE_STEEL_PLATES = new MaterialTrait()
         .setPartType(MaterialTrait.PROP_PLATES)


### PR DESCRIPTION
Steel rod tool exp buff was implemented in tick events. Moved to block break and entity damage events.

Iron links description incorrect. Changed "-10% armor durability loss" to "-10% outgoing damage".