### PR TITLE
Fix NPE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,11 +77,6 @@
             <id>aikar</id>
             <url>https://repo.aikar.co/content/groups/aikar/</url>
         </repository>
-        <repository>
-            <id>sefi-central</id>
-            <name>Sefiraat</name>
-            <url>https://sefiraat.jfrog.io/artifactory/default-maven-local</url>
-        </repository>
     </repositories>
 
     <!-- Thanks to dough here! -->
@@ -285,9 +280,9 @@
             <version>0.5.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>io.github.sefiraat</groupId>
+            <groupId>dev.sefiraat</groupId>
             <artifactId>networks</artifactId>
-            <version>MODIFIED_1.0.7</version>
+            <version>1.0.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/github/sefiraat/slimetinker/events/PlayerDamagedEvents.java
+++ b/src/main/java/io/github/sefiraat/slimetinker/events/PlayerDamagedEvents.java
@@ -639,10 +639,11 @@ public final class PlayerDamagedEvents {
     public static void plateIridium(EventFriend friend) {
         Player p = friend.getPlayer();
         Entity e = friend.getDamagingEntity();
-        if (e.getType() == EntityType.GUARDIAN) {
-            return;
-        }
         if (e instanceof Mob) {
+            if (e.getType() == EntityType.GUARDIAN) {
+                return;
+            }
+
             ((Mob) e).damage(friend.getInitialDamage() * 0.1, p);
             friend.setDamageMod(friend.getDamageMod() - 0.1);
         }


### PR DESCRIPTION
This event can be triggered via both EntityDamageEvent and EntityDamagedByEntityEvent, so the damage source can be null if from EntityDamageEvent, causing `getType()` throws NPE.